### PR TITLE
bugfix/1 - Projects listing is limited to 20 pages due to Prismic’s default GraphQL pagination limit

### DIFF
--- a/src/pages/projects/[projectId].tsx
+++ b/src/pages/projects/[projectId].tsx
@@ -279,7 +279,7 @@ export const getStaticPaths = async () => {
     const response = await client.query<{ allProjects: IdsNode }>({
         query: gql`
            query {
-              allProjects {
+              allProjects(first: 500) {
                 edges {
                   node {
                     _meta {


### PR DESCRIPTION
Fix for https://github.com/fundacja-kids/kids.org.pl/issues/1

Fixed by increasing GraphQL limit for allProjects call to 500 records